### PR TITLE
Add themed title, background, and icons

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,9 @@ func New() *gin.Engine {
 	r.Use(logRequests())
 	r.Static("/assets", "./web/assets")
 	r.Static("/ui", "./web/ui")
+	r.StaticFile("/favicon.ico", "./web/assets/favicon.ico")
+	r.StaticFile("/apple-touch-icon.png", "./web/assets/apple-touch-icon.png")
+	r.StaticFile("/apple-touch-icon-precomposed.png", "./web/assets/apple-touch-icon.png")
 
 	apiGroup := r.Group("/api")
 	{

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,15 @@
 <html lang="en" class="h-full">
 <head>
     <meta charset="UTF-8" />
+    <meta property="og:url" content="https://donkey.dvamin.app/" />
+    <meta property="og:title" content="Donkey" />
+    <meta property="og:description" content="Card Game with 2-8 players where a last-man loses." />
+    <meta property="og:site_name" content="Donkey" />
+    <meta property="og:image" content="https://donkey.dvamin.app/apple-touch-icon.png" />
     <title>Donkey</title>
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-precomposed.png" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>

--- a/web/ui/about.js
+++ b/web/ui/about.js
@@ -2,10 +2,11 @@ const React = window.React;
 
 export function AboutModal({version,onClose}){
   return React.createElement('div',{className:'fixed inset-0 flex items-center justify-center bg-black bg-opacity-50'},
-    React.createElement('div',{className:'bg-white dark:bg-slate-700 text-black dark:text-white p-4 rounded space-y-2 text-center'},[
-      React.createElement('h2',{className:'text-lg font-bold'},'DONKEY'),
-      React.createElement('p',null,`Version: ${version}`),
-      React.createElement('p',null,'Created by Deepak Amin.'),
+    React.createElement('div',{className:'bg-white dark:bg-slate-700 text-black dark:text-white p-4 rounded space-y-2'},[
+      React.createElement('h2',{className:'text-lg font-bold text-center'},'About'),
+      React.createElement('img',{src:'/apple-touch-icon.png',className:'mx-auto w-24 h-24',alt:'Donkey icon'}),
+      React.createElement('p',{className:'text-right'},`Version: ${version}`),
+      React.createElement('p',{className:'text-right'},'Created by Deepak Amin.'),
       React.createElement('button',{className:'mt-2 px-4 py-1 bg-pink-200 dark:bg-pink-700 text-black dark:text-white rounded',onClick:onClose},'Close')
     ])
   );

--- a/web/ui/app.js
+++ b/web/ui/app.js
@@ -135,9 +135,11 @@ function App(){
 
   const showShare = gameId && state && !state.hasStarted && !state.isAbandoned;
   const isRequester = state && state.requesterId==user.id;
+  const actualTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
 
-  return React.createElement('div',{className:'h-full flex flex-col items-center'},[
-    React.createElement('nav',{className:'fixed top-0 left-0 p-2'},[
+  return React.createElement('div',{className:'h-full flex flex-col items-center relative bg-slate-100 dark:bg-slate-800'},[
+    React.createElement('img',{src:`/assets/donkey-background-${actualTheme}.png`,className:'absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 max-w-full max-h-full opacity-20 pointer-events-none select-none'}),
+    React.createElement('nav',{className:'fixed top-0 left-0 p-2 z-10'},[
       React.createElement('div',{className:'relative'},[
         React.createElement('button',{className:'px-2 py-1 bg-blue-200 dark:bg-blue-700 text-black dark:text-white rounded',onClick:()=>setMenuOpen(!menuOpen)},'☰'),
         menuOpen && React.createElement('div',{className:'absolute mt-2 bg-white dark:bg-gray-800 text-black dark:text-white rounded shadow'},[
@@ -151,8 +153,10 @@ function App(){
         ])
       ])
     ]),
-    React.createElement('h1',{className:'text-3xl font-bold text-center mt-4'},'DONKEY'),
-    React.createElement('div',{className:'p-4 mt-8 space-y-4 flex flex-col items-center'},[
+    React.createElement('div',{className:'mt-4 w-full flex justify-center items-center h-12 bg-white dark:bg-gray-900 z-10'},[
+      React.createElement('img',{src:`/assets/donkey-title-${actualTheme}.png`,className:'h-full w-auto',alt:'Donkey title'})
+    ]),
+    React.createElement('div',{className:'p-4 mt-8 space-y-4 flex flex-col items-center z-10'},[
       state && !state.hasStarted && isRequester &&
         React.createElement('button',{
           className:`px-3 py-1 bg-green-200 dark:bg-green-700 text-black dark:text-white rounded ${state.players.length>1?'':'opacity-50 cursor-not-allowed'}`,
@@ -168,10 +172,10 @@ function App(){
     showShare && React.createElement(ShareModal,{gameId,isRequester,playerCount:state?state.players.length:1,onFinalize:finalize}),
     showReg && React.createElement(RegistrationModal,{onSubmit:register}),
     showAbandoned && React.createElement(AbandonedModal,{onClose:closeAbandoned}),
-    React.createElement('div',{className:`fixed bottom-0 right-0 m-2 text-xs px-2 py-1 rounded ${connected?'bg-green-500':'bg-red-500'} text-white`},
+    React.createElement('div',{className:`fixed bottom-0 right-0 m-2 text-xs px-2 py-1 rounded ${connected?'bg-green-500':'bg-red-500'} text-white z-10`},
       user.name ? `${user.name}: ${connected?'Connected':'Disconnected'}` : (connected?'Connected':'Disconnected')
     ),
-    gameId && React.createElement('div',{className:'fixed bottom-0 left-0 m-2 w-64'},[
+    gameId && React.createElement('div',{className:'fixed bottom-0 left-0 m-2 w-64 z-10'},[
       React.createElement('div',{className:'bg-white dark:bg-gray-800 text-black dark:text-white border rounded'},[
         React.createElement('div',{className:'flex justify-between items-center px-2 py-1 border-b'},[
           React.createElement('span',null,'Session Updates'),


### PR DESCRIPTION
## Summary
- Replace text title with themed image and add subtle themed board background
- Serve favicon and touch icon (including precomposed alias) and reference them in the page
- Add Open Graph meta tags for Slack unfurling and update About modal to show app icon and right-aligned details

## Testing
- `node --check web/ui/app.js`
- `node --check web/ui/about.js`
- `go test ./...` *(hangs; terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6899638275c8832fa18a1d20894c14d7