### PR TITLE
fix: add claude to allowed_bots in GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
• Fixes bot actor rejection error in GitHub Actions workflow
• Adds `allowed_bots: "claude"` to the claude-code-action configuration
• Resolves "Workflow initiated by non-human actor: claude (type: Bot)" error

## Test plan
- [ ] Verify workflow runs successfully when triggered by Claude
- [ ] Confirm no regression in existing workflow functionality

🤖 Generated with [Claude Code](https://claude.ai/code)